### PR TITLE
Add mastery progress bottom bar with slide-up guide

### DIFF
--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -62,6 +62,7 @@ import OnboardingSkipBadge from "@/components/layout/OnboardingSkipBadge";
 import { useTour } from "@/contexts/TourContext";
 import PlatformTour from "@/components/tour/PlatformTour";
 import MasteryChecklist from "@/components/layout/MasteryChecklist";
+import MasteryBottomBar from "@/components/layout/MasteryBottomBar";
 import { getMastery } from "@/lib/masteryStorage";
 
 interface DashboardLayoutProps {
@@ -700,15 +701,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               {/* Right side - Notification, G2 Reviews, Profile */}
               <div className="flex items-center space-x-4">
                 <OnboardingSkipBadge />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setMasteryOpen(true)}
-                  className="h-8 px-3 text-xs font-semibold bg-gradient-to-r from-valasys-orange to-valasys-orange-light text-white hover:opacity-90"
-                  title="Open VAIS Mastery"
-                >
-                  VAIS Mastery
-                </Button>
                 <div className="flex items-center space-x-3">
                   {/* Notification Dropdown */}
                   <div data-tour="notifications" className="relative">
@@ -1024,6 +1016,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
         {/* Main Content */}
         <main className="relative flex-1 p-6 overflow-auto">{children}</main>
+        <MasteryBottomBar onOpen={() => setMasteryOpen(true)} />
       </div>
 
       {/* Manage Users Tooltip Portal (renders outside sidebar) */}

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -61,9 +61,7 @@ import TrialBadgeDropdown from "@/components/ui/trial-badge-dropdown";
 import OnboardingSkipBadge from "@/components/layout/OnboardingSkipBadge";
 import { useTour } from "@/contexts/TourContext";
 import PlatformTour from "@/components/tour/PlatformTour";
-import MasteryChecklist from "@/components/layout/MasteryChecklist";
 import MasteryBottomBar from "@/components/layout/MasteryBottomBar";
-import { getMastery, calculateMasteryPercentage } from "@/lib/masteryStorage";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -147,7 +145,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   }, []);
 
   const [chatOpen, setChatOpen] = useState(false);
-  const [masteryOpen, setMasteryOpen] = useState(false);
 
   // Tooltip state for disabled Manage Users item (rendered via portal outside sidebar)
   const [manageUsersTooltipVisible, setManageUsersTooltipVisible] =
@@ -160,14 +157,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   // Contact Sales dialog
   const [showContactSalesDialog, setShowContactSalesDialog] = useState(false);
 
-  // Auto-open Mastery Checklist when mastery is incomplete
-  useEffect(() => {
-    try {
-      const m = getMastery();
-      const percent = calculateMasteryPercentage(m);
-      if (percent < 100) setMasteryOpen(true);
-    } catch {}
-  }, []);
 
   const showManageUsersTooltip = (e: React.MouseEvent) => {
     const el = e.currentTarget as HTMLElement;
@@ -650,7 +639,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       >
         {/* Top Header */}
         <header className="bg-white shadow-sm border-b border-valasys-gray-200 sticky top-0 z-40 pt-2 sm:pt-4 lg:pt-10">
-          <MasteryChecklist open={masteryOpen} onOpenChange={setMasteryOpen} />
           <TrialBanner
             className="fixed inset-x-0 top-0 z-[60]"
             daysUsed={5}
@@ -1017,7 +1005,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
         {/* Main Content */}
         <main className="relative flex-1 p-6 overflow-auto">{children}</main>
-        <MasteryBottomBar onOpen={() => setMasteryOpen(true)} />
+        <MasteryBottomBar />
       </div>
 
       {/* Manage Users Tooltip Portal (renders outside sidebar) */}

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -157,7 +157,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   // Contact Sales dialog
   const [showContactSalesDialog, setShowContactSalesDialog] = useState(false);
 
-
   const showManageUsersTooltip = (e: React.MouseEvent) => {
     const el = e.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -63,7 +63,7 @@ import { useTour } from "@/contexts/TourContext";
 import PlatformTour from "@/components/tour/PlatformTour";
 import MasteryChecklist from "@/components/layout/MasteryChecklist";
 import MasteryBottomBar from "@/components/layout/MasteryBottomBar";
-import { getMastery } from "@/lib/masteryStorage";
+import { getMastery, calculateMasteryPercentage } from "@/lib/masteryStorage";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -160,11 +160,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   // Contact Sales dialog
   const [showContactSalesDialog, setShowContactSalesDialog] = useState(false);
 
-  // Auto-open Mastery Checklist for new users (first login / not dismissed)
+  // Auto-open Mastery Checklist when mastery is incomplete
   useEffect(() => {
     try {
       const m = getMastery();
-      if (!m.dismissed) setMasteryOpen(true);
+      const percent = calculateMasteryPercentage(m);
+      if (percent < 100) setMasteryOpen(true);
     } catch {}
   }, []);
 

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -61,6 +61,8 @@ import TrialBadgeDropdown from "@/components/ui/trial-badge-dropdown";
 import OnboardingSkipBadge from "@/components/layout/OnboardingSkipBadge";
 import { useTour } from "@/contexts/TourContext";
 import PlatformTour from "@/components/tour/PlatformTour";
+import MasteryChecklist from "@/components/layout/MasteryChecklist";
+import { getMastery } from "@/lib/masteryStorage";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -144,6 +146,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   }, []);
 
   const [chatOpen, setChatOpen] = useState(false);
+  const [masteryOpen, setMasteryOpen] = useState(false);
 
   // Tooltip state for disabled Manage Users item (rendered via portal outside sidebar)
   const [manageUsersTooltipVisible, setManageUsersTooltipVisible] =
@@ -155,6 +158,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   // Contact Sales dialog
   const [showContactSalesDialog, setShowContactSalesDialog] = useState(false);
+
+  // Auto-open Mastery Checklist for new users (first login / not dismissed)
+  useEffect(() => {
+    try {
+      const m = getMastery();
+      if (!m.dismissed) setMasteryOpen(true);
+    } catch {}
+  }, []);
 
   const showManageUsersTooltip = (e: React.MouseEvent) => {
     const el = e.currentTarget as HTMLElement;
@@ -637,6 +648,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       >
         {/* Top Header */}
         <header className="bg-white shadow-sm border-b border-valasys-gray-200 sticky top-0 z-40 pt-2 sm:pt-4 lg:pt-10">
+          <MasteryChecklist open={masteryOpen} onOpenChange={setMasteryOpen} />
           <TrialBanner
             className="fixed inset-x-0 top-0 z-[60]"
             daysUsed={5}
@@ -688,6 +700,15 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               {/* Right side - Notification, G2 Reviews, Profile */}
               <div className="flex items-center space-x-4">
                 <OnboardingSkipBadge />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMasteryOpen(true)}
+                  className="h-8 px-3 text-xs font-semibold bg-gradient-to-r from-valasys-orange to-valasys-orange-light text-white hover:opacity-90"
+                  title="Open VAIS Mastery"
+                >
+                  VAIS Mastery
+                </Button>
                 <div className="flex items-center space-x-3">
                   {/* Notification Dropdown */}
                   <div data-tour="notifications" className="relative">

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { X } from "lucide-react";
+import { X, CheckCircle, Circle } from "lucide-react";
 import { Progress } from "@/components/ui/progress";
 import {
   calculateMasteryPercentage,
@@ -8,14 +8,12 @@ import {
   MasterySteps,
   MASTERY_EVENT,
 } from "@/lib/masteryStorage";
+import { AnimatePresence, motion } from "framer-motion";
 
-export default function MasteryBottomBar({
-  onOpen,
-}: {
-  onOpen: () => void;
-}) {
+export default function MasteryBottomBar() {
   const [state, setState] = useState<MasterySteps>({});
   const [hidden, setHidden] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     setState(getMastery());
@@ -28,12 +26,85 @@ export default function MasteryBottomBar({
     };
   }, []);
 
+  const steps = useMemo(
+    () => [
+      { label: "Sign up to VAIS", completed: true },
+      {
+        label:
+          "Complete the onboarding questions — Hint: Complete your onboarding process and get free credits 🎉",
+        completed: !!state.onboardingCompleted,
+      },
+      { label: "Generate your VAIS Results", completed: !!state.vaisResultsGenerated },
+      {
+        label: "Download the Accounts from the VAIS Results page",
+        completed: !!state.accountsDownloaded,
+      },
+      { label: "Generate the Prospect Search", completed: !!state.prospectSearchGenerated },
+      { label: "Download the Prospect Details", completed: !!state.prospectDetailsDownloaded },
+    ],
+    [state],
+  );
+
   const percent = calculateMasteryPercentage(state);
   if (hidden || percent >= 100) return null;
 
   return (
     <div className="fixed inset-x-0 bottom-4 z-50 pointer-events-none">
       <div className="mx-auto w-[min(92vw,520px)] pointer-events-auto">
+        {/* Slide-up panel */}
+        <AnimatePresence initial={false}>
+          {expanded && (
+            <motion.div
+              key="panel"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 16 }}
+              transition={{ duration: 0.18, ease: "easeOut" }}
+              className="mb-2 rounded-xl shadow-xl bg-white overflow-hidden"
+            >
+              <div className="px-5 pt-4 pb-3">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <h2 className="text-[15px] font-semibold text-[#333333]">
+                      VAIS Mastery Steps Guide
+                    </h2>
+                    <p className="text-xs text-[#666] mt-0.5">
+                      Complete these steps to unlock your full VAIS potential 🚀
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close"
+                    className="text-gray-400 hover:text-gray-600"
+                    onClick={() => setExpanded(false)}
+                    title="Close"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="mt-3 h-px bg-gray-200" />
+              </div>
+
+              <div className="px-5 pb-4 max-h-[360px] overflow-y-auto">
+                <ul className="space-y-3">
+                  {steps.map((s, idx) => (
+                    <li key={idx} className="flex items-start gap-3">
+                      <div className="mt-0.5">
+                        {s.completed ? (
+                          <CheckCircle className="w-5 h-5 text-[#4CAF50]" />
+                        ) : (
+                          <Circle className="w-5 h-5 text-gray-300" />
+                        )}
+                      </div>
+                      <div className="text-sm text-[#333333] leading-5">{s.label}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Bottom orange bar */}
         <div className="relative flex items-center gap-3 rounded-xl shadow-lg px-3 sm:px-4 py-2 sm:py-2.5 bg-gradient-to-r from-[#FF7A00] to-[#FFB347] text-white">
           {/* Avatar */}
           <div className="flex-shrink-0 hidden sm:block">
@@ -44,7 +115,7 @@ export default function MasteryBottomBar({
           </div>
 
           {/* Bar content */}
-          <button onClick={onOpen} className="flex-1 text-left">
+          <button onClick={() => setExpanded((v) => !v)} className="flex-1 text-left">
             <div className="flex items-center gap-3">
               <div className="flex-1">
                 <div className="relative">
@@ -59,7 +130,7 @@ export default function MasteryBottomBar({
             </div>
           </button>
 
-          {/* Close */}
+          {/* Hide bottom bar for this session */}
           <button
             aria-label="Hide for now"
             onClick={() => setHidden(true)}

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { X } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+import {
+  calculateMasteryPercentage,
+  getMastery,
+  MasterySteps,
+  setMasteryDismissed,
+} from "@/lib/masteryStorage";
+
+export default function MasteryBottomBar({
+  onOpen,
+}: {
+  onOpen: () => void;
+}) {
+  const [state, setState] = useState<MasterySteps>({});
+
+  useEffect(() => {
+    setState(getMastery());
+    const id = setInterval(() => setState(getMastery()), 800);
+    return () => clearInterval(id);
+  }, []);
+
+  if (state.dismissed) return null;
+
+  const percent = calculateMasteryPercentage(state);
+
+  return (
+    <div className="fixed inset-x-0 bottom-4 z-50 pointer-events-none">
+      <div className="mx-auto w-[min(92vw,520px)] pointer-events-auto">
+        <div className="relative flex items-center gap-3 rounded-xl shadow-lg px-3 sm:px-4 py-2 sm:py-2.5 bg-gradient-to-r from-[#FF7A00] to-[#FFB347] text-white">
+          {/* Avatar */}
+          <div className="flex-shrink-0 hidden sm:block">
+            <Avatar className="h-7 w-7">
+              <AvatarImage src="" alt="VAIS" />
+              <AvatarFallback className="bg-white/30 text-white text-[10px]">VA</AvatarFallback>
+            </Avatar>
+          </div>
+
+          {/* Bar content */}
+          <button onClick={onOpen} className="flex-1 text-left">
+            <div className="flex items-center gap-3">
+              <div className="flex-1">
+                <div className="relative">
+                  <Progress value={percent} className="h-3 bg-[#F1F1F1]" />
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-[11px] font-semibold drop-shadow-sm">
+                      Your VAIS mastery: {percent}%
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </button>
+
+          {/* Close */}
+          <button
+            aria-label="Dismiss mastery"
+            onClick={() => setMasteryDismissed(true)}
+            className="ml-1 rounded-md/7 hover:opacity-90"
+            title="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -58,7 +58,7 @@ export default function MasteryBottomBar({
           <button
             aria-label="Dismiss mastery"
             onClick={() => setMasteryDismissed(true)}
-            className="ml-1 rounded-md/7 hover:opacity-90"
+            className="ml-1 rounded-md hover:opacity-90"
             title="Dismiss"
           >
             <X className="h-4 w-4" />

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -18,7 +18,8 @@ export default function MasteryBottomBar() {
 
   useEffect(() => {
     setState(getMastery());
-    const onUpdate = (e: Event) => setState((e as CustomEvent).detail as MasterySteps);
+    const onUpdate = (e: Event) =>
+      setState((e as CustomEvent).detail as MasterySteps);
     window.addEventListener(MASTERY_EVENT, onUpdate as EventListener);
     const id = setInterval(() => setState(getMastery()), 3000);
     return () => {
@@ -36,14 +37,26 @@ export default function MasteryBottomBar() {
           "Complete the onboarding questions — Hint: Complete your onboarding process and get free credits 🎉",
         completed: !!state.onboardingCompleted,
       },
-      { key: "vaisResultsGenerated", label: "Generate your VAIS Results", completed: !!state.vaisResultsGenerated },
+      {
+        key: "vaisResultsGenerated",
+        label: "Generate your VAIS Results",
+        completed: !!state.vaisResultsGenerated,
+      },
       {
         key: "accountsDownloaded",
         label: "Download the Accounts from the VAIS Results page",
         completed: !!state.accountsDownloaded,
       },
-      { key: "prospectSearchGenerated", label: "Generate the Prospect Search", completed: !!state.prospectSearchGenerated },
-      { key: "prospectDetailsDownloaded", label: "Download the Prospect Details", completed: !!state.prospectDetailsDownloaded },
+      {
+        key: "prospectSearchGenerated",
+        label: "Generate the Prospect Search",
+        completed: !!state.prospectSearchGenerated,
+      },
+      {
+        key: "prospectDetailsDownloaded",
+        label: "Download the Prospect Details",
+        completed: !!state.prospectDetailsDownloaded,
+      },
     ],
     [state],
   );
@@ -112,7 +125,9 @@ export default function MasteryBottomBar() {
                           <Circle className="w-5 h-5 text-gray-300" />
                         )}
                       </div>
-                      <div className="text-sm text-[#333333] leading-5">{s.label}</div>
+                      <div className="text-sm text-[#333333] leading-5">
+                        {s.label}
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -154,16 +169,26 @@ export default function MasteryBottomBar() {
             <div className="flex-shrink-0 hidden sm:block">
               <Avatar className="h-7 w-7">
                 <AvatarImage src="" alt="VAIS" />
-                <AvatarFallback className="bg-white/30 text-white text-[10px]">VA</AvatarFallback>
+                <AvatarFallback className="bg-white/30 text-white text-[10px]">
+                  VA
+                </AvatarFallback>
               </Avatar>
             </div>
 
-            <button onClick={() => setExpanded((v) => !v)} className="flex-1 text-left">
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="flex-1 text-left"
+            >
               <div className="flex items-center gap-3">
                 <div className="flex-1">
                   <Progress value={percent} className="h-[14px] bg-[#F1F1F1]" />
                 </div>
-                <ChevronUp className={"h-4 w-4 transition-transform " + (expanded ? "rotate-180" : "")} />
+                <ChevronUp
+                  className={
+                    "h-4 w-4 transition-transform " +
+                    (expanded ? "rotate-180" : "")
+                  }
+                />
               </div>
             </button>
 

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { X, CheckCircle, Circle } from "lucide-react";
+import { X, CheckCircle, Circle, ChevronUp } from "lucide-react";
 import { Progress } from "@/components/ui/progress";
+import { Link } from "react-router-dom";
 import {
   calculateMasteryPercentage,
   getMastery,

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -121,58 +121,66 @@ export default function MasteryBottomBar() {
           )}
         </AnimatePresence>
 
-        {/* Bottom orange bar */}
-        <div className="relative flex items-center gap-3 rounded-xl shadow-lg px-3 sm:px-4 py-2 sm:py-2.5 bg-gradient-to-r from-[#FF7A00] to-[#FFB347] text-white">
-          {/* Avatar */}
-          <div className="flex-shrink-0 hidden sm:block">
-            <Avatar className="h-7 w-7">
-              <AvatarImage src="" alt="VAIS" />
-              <AvatarFallback className="bg-white/30 text-white text-[10px]">VA</AvatarFallback>
-            </Avatar>
-          </div>
-
-          {/* Bar content (toggle expand) */}
-          <button onClick={() => setExpanded((v) => !v)} className="flex-1 text-left">
-            <div className="flex items-center gap-3">
-              <div className="flex-1">
-                <div className="relative">
-                  <Progress value={percent} className="h-3 bg-[#F1F1F1]" />
-                  <div className="absolute inset-0 flex items-center justify-center">
-                    <span className="text-[11px] font-semibold drop-shadow-sm">
-                      Your VAIS mastery: {percent}%
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <ChevronUp className={"h-4 w-4 transition-transform " + (expanded ? "rotate-180" : "")} />
+        {/* Next up suggestion (shown when collapsed) */}
+        {!expanded && next && (
+          <div className="mb-2 flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2 shadow-sm">
+            <div className="text-[13px]">
+              <span className="font-semibold text-[#FF7A00]">Next up: </span>
+              <span className="text-[#333]">{next.label}</span>
             </div>
-          </button>
-
-          {/* Next suggested step CTA */}
-          {next && (
-            <div className="hidden sm:flex items-center gap-2 pl-2">
-              <span className="text-[11px] font-semibold">Next:</span>
-              <span className="text-[11px] line-clamp-1 max-w-[160px]">{next.label}</span>
+            <div className="flex items-center gap-2">
+              <button
+                className="text-xs font-semibold text-[#FF7A00] hover:underline"
+                onClick={() => setExpanded(true)}
+                title="Open guide"
+              >
+                Details
+              </button>
               <Link
                 to={next.to}
-                onClick={(e) => e.stopPropagation()}
-                className="ml-1 inline-flex items-center px-2 py-1 rounded-md text-[#FF7A00] bg-white text-[11px] font-semibold hover:opacity-90"
+                className="inline-flex items-center rounded-md bg-[#FF7A00] px-2 py-1 text-xs font-semibold text-white hover:opacity-90"
                 title="Go"
               >
                 Go
               </Link>
             </div>
-          )}
+          </div>
+        )}
 
-          {/* Hide bottom bar for this session */}
-          <button
-            aria-label="Hide for now"
-            onClick={() => setHidden(true)}
-            className="ml-1 rounded-md hover:opacity-90"
-            title="Hide for now"
-          >
-            <X className="h-4 w-4" />
-          </button>
+        {/* Bottom orange bar */}
+        <div className="relative flex flex-col gap-1 rounded-xl shadow-lg px-3 sm:px-4 py-2.5 sm:py-3 bg-gradient-to-r from-[#FF7A00] to-[#FFB347] text-white">
+          {/* Top row: avatar, progress, chevron, close */}
+          <div className="flex items-center gap-3">
+            <div className="flex-shrink-0 hidden sm:block">
+              <Avatar className="h-7 w-7">
+                <AvatarImage src="" alt="VAIS" />
+                <AvatarFallback className="bg-white/30 text-white text-[10px]">VA</AvatarFallback>
+              </Avatar>
+            </div>
+
+            <button onClick={() => setExpanded((v) => !v)} className="flex-1 text-left">
+              <div className="flex items-center gap-3">
+                <div className="flex-1">
+                  <Progress value={percent} className="h-[14px] bg-[#F1F1F1]" />
+                </div>
+                <ChevronUp className={"h-4 w-4 transition-transform " + (expanded ? "rotate-180" : "")} />
+              </div>
+            </button>
+
+            <button
+              aria-label="Hide for now"
+              onClick={() => setHidden(true)}
+              className="ml-1 rounded-md hover:opacity-90"
+              title="Hide for now"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* Bottom text */}
+          <div className="text-center text-[12px] font-semibold">
+            Your VAIS mastery: {percent}%
+          </div>
         </div>
       </div>
     </div>

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -6,7 +6,6 @@ import {
   calculateMasteryPercentage,
   getMastery,
   MasterySteps,
-  setMasteryDismissed,
   MASTERY_EVENT,
 } from "@/lib/masteryStorage";
 
@@ -16,6 +15,7 @@ export default function MasteryBottomBar({
   onOpen: () => void;
 }) {
   const [state, setState] = useState<MasterySteps>({});
+  const [hidden, setHidden] = useState(false);
 
   useEffect(() => {
     setState(getMastery());
@@ -28,9 +28,8 @@ export default function MasteryBottomBar({
     };
   }, []);
 
-  if (state.dismissed) return null;
-
   const percent = calculateMasteryPercentage(state);
+  if (hidden || percent >= 100) return null;
 
   return (
     <div className="fixed inset-x-0 bottom-4 z-50 pointer-events-none">
@@ -62,10 +61,10 @@ export default function MasteryBottomBar({
 
           {/* Close */}
           <button
-            aria-label="Dismiss mastery"
-            onClick={() => setMasteryDismissed(true)}
+            aria-label="Hide for now"
+            onClick={() => setHidden(true)}
             className="ml-1 rounded-md hover:opacity-90"
-            title="Dismiss"
+            title="Hide for now"
           >
             <X className="h-4 w-4" />
           </button>

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -7,6 +7,7 @@ import {
   getMastery,
   MasterySteps,
   setMasteryDismissed,
+  MASTERY_EVENT,
 } from "@/lib/masteryStorage";
 
 export default function MasteryBottomBar({
@@ -18,8 +19,13 @@ export default function MasteryBottomBar({
 
   useEffect(() => {
     setState(getMastery());
-    const id = setInterval(() => setState(getMastery()), 800);
-    return () => clearInterval(id);
+    const onUpdate = (e: Event) => setState((e as CustomEvent).detail as MasterySteps);
+    window.addEventListener(MASTERY_EVENT, onUpdate as EventListener);
+    const id = setInterval(() => setState(getMastery()), 3000);
+    return () => {
+      window.removeEventListener(MASTERY_EVENT, onUpdate as EventListener);
+      clearInterval(id);
+    };
   }, []);
 
   if (state.dismissed) return null;

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -138,7 +138,7 @@ export default function MasteryBottomBar() {
               </button>
               <Link
                 to={next.to}
-                className="inline-flex items-center rounded-md bg-[#FF7A00] px-2 py-1 text-xs font-semibold text-white hover:opacity-90"
+                className="inline-flex items-center rounded-md bg-valasys-orange hover:bg-valasys-orange-light px-2 py-1 text-xs font-semibold text-white"
                 title="Go"
               >
                 Go
@@ -148,7 +148,7 @@ export default function MasteryBottomBar() {
         )}
 
         {/* Bottom orange bar */}
-        <div className="relative flex flex-col gap-1 rounded-xl shadow-lg px-3 sm:px-4 py-2.5 sm:py-3 bg-gradient-to-r from-[#FF7A00] to-[#FFB347] text-white">
+        <div className="relative flex flex-col gap-1 rounded-xl shadow-lg px-3 sm:px-4 py-2.5 sm:py-3 bg-gradient-to-r from-valasys-orange to-valasys-orange-light text-white">
           {/* Top row: avatar, progress, chevron, close */}
           <div className="flex items-center gap-3">
             <div className="flex-shrink-0 hidden sm:block">

--- a/client/components/layout/MasteryBottomBar.tsx
+++ b/client/components/layout/MasteryBottomBar.tsx
@@ -29,22 +29,38 @@ export default function MasteryBottomBar() {
 
   const steps = useMemo(
     () => [
-      { label: "Sign up to VAIS", completed: true },
+      { key: "signUp", label: "Sign up to VAIS", completed: true },
       {
+        key: "onboardingCompleted",
         label:
           "Complete the onboarding questions — Hint: Complete your onboarding process and get free credits 🎉",
         completed: !!state.onboardingCompleted,
       },
-      { label: "Generate your VAIS Results", completed: !!state.vaisResultsGenerated },
+      { key: "vaisResultsGenerated", label: "Generate your VAIS Results", completed: !!state.vaisResultsGenerated },
       {
+        key: "accountsDownloaded",
         label: "Download the Accounts from the VAIS Results page",
         completed: !!state.accountsDownloaded,
       },
-      { label: "Generate the Prospect Search", completed: !!state.prospectSearchGenerated },
-      { label: "Download the Prospect Details", completed: !!state.prospectDetailsDownloaded },
+      { key: "prospectSearchGenerated", label: "Generate the Prospect Search", completed: !!state.prospectSearchGenerated },
+      { key: "prospectDetailsDownloaded", label: "Download the Prospect Details", completed: !!state.prospectDetailsDownloaded },
     ],
     [state],
   );
+
+  const next = useMemo(() => {
+    if (!state.onboardingCompleted)
+      return { label: "Complete onboarding", to: "/onboarding/role" };
+    if (!state.vaisResultsGenerated)
+      return { label: "Generate VAIS Results", to: "/build-vais" };
+    if (!state.accountsDownloaded)
+      return { label: "Download Accounts", to: "/vais-results" };
+    if (!state.prospectSearchGenerated)
+      return { label: "Generate Prospect Search", to: "/find-prospect" };
+    if (!state.prospectDetailsDownloaded)
+      return { label: "Download Prospect Details", to: "/prospect-results" };
+    return null;
+  }, [state]);
 
   const percent = calculateMasteryPercentage(state);
   if (hidden || percent >= 100) return null;
@@ -115,7 +131,7 @@ export default function MasteryBottomBar() {
             </Avatar>
           </div>
 
-          {/* Bar content */}
+          {/* Bar content (toggle expand) */}
           <button onClick={() => setExpanded((v) => !v)} className="flex-1 text-left">
             <div className="flex items-center gap-3">
               <div className="flex-1">
@@ -128,8 +144,25 @@ export default function MasteryBottomBar() {
                   </div>
                 </div>
               </div>
+              <ChevronUp className={"h-4 w-4 transition-transform " + (expanded ? "rotate-180" : "")} />
             </div>
           </button>
+
+          {/* Next suggested step CTA */}
+          {next && (
+            <div className="hidden sm:flex items-center gap-2 pl-2">
+              <span className="text-[11px] font-semibold">Next:</span>
+              <span className="text-[11px] line-clamp-1 max-w-[160px]">{next.label}</span>
+              <Link
+                to={next.to}
+                onClick={(e) => e.stopPropagation()}
+                className="ml-1 inline-flex items-center px-2 py-1 rounded-md text-[#FF7A00] bg-white text-[11px] font-semibold hover:opacity-90"
+                title="Go"
+              >
+                Go
+              </Link>
+            </div>
+          )}
 
           {/* Hide bottom bar for this session */}
           <button

--- a/client/components/layout/MasteryChecklist.tsx
+++ b/client/components/layout/MasteryChecklist.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import { CheckCircle, Circle } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  calculateMasteryPercentage,
+  getMastery,
+  MASTERY_EVENT,
+  MasterySteps,
+  setMasteryDismissed,
+} from "@/lib/masteryStorage";
+
+export default function MasteryChecklist({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}) {
+  const [state, setState] = useState<MasterySteps>({});
+
+  useEffect(() => {
+    setState(getMastery());
+    const onUpdate = (e: Event) => {
+      const detail = (e as CustomEvent).detail as MasterySteps;
+      setState(detail);
+    };
+    window.addEventListener(MASTERY_EVENT, onUpdate as EventListener);
+    return () => window.removeEventListener(MASTERY_EVENT, onUpdate as EventListener);
+  }, []);
+
+  const percent = useMemo(() => calculateMasteryPercentage(state), [state]);
+
+  const steps = [
+    { label: "Sign up to VAIS", completed: true },
+    {
+      label:
+        "Complete the onboarding questions — Hint: Complete your onboarding process and get free credits 🎉",
+      completed: !!state.onboardingCompleted,
+    },
+    { label: "Generate your VAIS Results", completed: !!state.vaisResultsGenerated },
+    {
+      label: "Download the Accounts from the VAIS Results page",
+      completed: !!state.accountsDownloaded,
+    },
+    { label: "Generate the Prospect Search", completed: !!state.prospectSearchGenerated },
+    { label: "Download the Prospect Details", completed: !!state.prospectDetailsDownloaded },
+  ];
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v) setMasteryDismissed(true);
+    onOpenChange(v);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-[500px] p-0 overflow-hidden">
+        <div className="bg-white rounded-lg shadow-xl max-h-[540px]">
+          {/* Header */}
+          <div className="px-6 pt-5 pb-4">
+            <h2 className="text-xl font-semibold text-[#333333]">VAIS Mastery Steps Guide</h2>
+            <p className="text-sm text-[#666] mt-1">
+              Complete these steps to unlock your full VAIS potential 🚀
+            </p>
+            <div className="mt-4 h-px bg-gray-200" />
+          </div>
+
+          {/* Steps */}
+          <div className="px-6 pb-4 overflow-y-auto max-h-[360px]">
+            <ul className="space-y-3">
+              {steps.map((s, idx) => (
+                <li key={idx} className="flex items-start gap-3">
+                  <div className="mt-0.5">
+                    <AnimatePresence initial={false}>
+                      {s.completed ? (
+                        <motion.div
+                          initial={{ scale: 0.6, opacity: 0 }}
+                          animate={{ scale: 1, opacity: 1 }}
+                          exit={{ scale: 0.6, opacity: 0 }}
+                          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                        >
+                          <CheckCircle className="w-5 h-5 text-[#4CAF50]" />
+                        </motion.div>
+                      ) : (
+                        <Circle className="w-5 h-5 text-gray-300" />
+                      )}
+                    </AnimatePresence>
+                  </div>
+                  <div className="text-sm text-[#333333] leading-5">{s.label}</div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Footer progress */}
+          <div className="px-6 pb-6">
+            <div className="relative">
+              <Progress value={percent} className="h-4 bg-[#F1F1F1]" />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="text-xs font-medium text-white drop-shadow-sm">
+                  Your VAIS mastery: {percent}%
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/components/layout/MasteryChecklist.tsx
+++ b/client/components/layout/MasteryChecklist.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { CheckCircle, Circle } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -27,7 +32,8 @@ export default function MasteryChecklist({
       setState(detail);
     };
     window.addEventListener(MASTERY_EVENT, onUpdate as EventListener);
-    return () => window.removeEventListener(MASTERY_EVENT, onUpdate as EventListener);
+    return () =>
+      window.removeEventListener(MASTERY_EVENT, onUpdate as EventListener);
   }, []);
 
   const percent = useMemo(() => calculateMasteryPercentage(state), [state]);
@@ -39,13 +45,22 @@ export default function MasteryChecklist({
         "Complete the onboarding questions — Hint: Complete your onboarding process and get free credits 🎉",
       completed: !!state.onboardingCompleted,
     },
-    { label: "Generate your VAIS Results", completed: !!state.vaisResultsGenerated },
+    {
+      label: "Generate your VAIS Results",
+      completed: !!state.vaisResultsGenerated,
+    },
     {
       label: "Download the Accounts from the VAIS Results page",
       completed: !!state.accountsDownloaded,
     },
-    { label: "Generate the Prospect Search", completed: !!state.prospectSearchGenerated },
-    { label: "Download the Prospect Details", completed: !!state.prospectDetailsDownloaded },
+    {
+      label: "Generate the Prospect Search",
+      completed: !!state.prospectSearchGenerated,
+    },
+    {
+      label: "Download the Prospect Details",
+      completed: !!state.prospectDetailsDownloaded,
+    },
   ];
 
   const handleOpenChange = (v: boolean) => {
@@ -57,11 +72,15 @@ export default function MasteryChecklist({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[500px] p-0 overflow-hidden">
         <DialogTitle className="sr-only">VAIS Mastery Steps Guide</DialogTitle>
-        <DialogDescription className="sr-only">Complete these steps to unlock your full VAIS potential</DialogDescription>
+        <DialogDescription className="sr-only">
+          Complete these steps to unlock your full VAIS potential
+        </DialogDescription>
         <div className="bg-white rounded-lg shadow-xl max-h-[540px]">
           {/* Header */}
           <div className="px-6 pt-5 pb-4 relative">
-            <h2 className="text-xl font-semibold text-[#333333]">VAIS Mastery Steps Guide</h2>
+            <h2 className="text-xl font-semibold text-[#333333]">
+              VAIS Mastery Steps Guide
+            </h2>
             <p className="text-sm text-[#666] mt-1">
               Complete these steps to unlock your full VAIS potential 🚀
             </p>
@@ -90,7 +109,11 @@ export default function MasteryChecklist({
                           initial={{ scale: 0.6, opacity: 0 }}
                           animate={{ scale: 1, opacity: 1 }}
                           exit={{ scale: 0.6, opacity: 0 }}
-                          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                          transition={{
+                            type: "spring",
+                            stiffness: 300,
+                            damping: 20,
+                          }}
                         >
                           <CheckCircle className="w-5 h-5 text-[#4CAF50]" />
                         </motion.div>
@@ -99,7 +122,9 @@ export default function MasteryChecklist({
                       )}
                     </AnimatePresence>
                   </div>
-                  <div className="text-sm text-[#333333] leading-5">{s.label}</div>
+                  <div className="text-sm text-[#333333] leading-5">
+                    {s.label}
+                  </div>
                 </li>
               ))}
             </ul>

--- a/client/components/layout/MasteryChecklist.tsx
+++ b/client/components/layout/MasteryChecklist.tsx
@@ -69,10 +69,9 @@ export default function MasteryChecklist({
               aria-label="Close"
               className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
               onClick={() => {
-                setMasteryDismissed(true);
                 onOpenChange(false);
               }}
-              title="Dismiss"
+              title="Close"
             >
               ✕
             </button>

--- a/client/components/layout/MasteryChecklist.tsx
+++ b/client/components/layout/MasteryChecklist.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { CheckCircle, Circle } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -56,6 +56,8 @@ export default function MasteryChecklist({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[500px] p-0 overflow-hidden">
+        <DialogTitle className="sr-only">VAIS Mastery Steps Guide</DialogTitle>
+        <DialogDescription className="sr-only">Complete these steps to unlock your full VAIS potential</DialogDescription>
         <div className="bg-white rounded-lg shadow-xl max-h-[540px]">
           {/* Header */}
           <div className="px-6 pt-5 pb-4">

--- a/client/components/layout/MasteryChecklist.tsx
+++ b/client/components/layout/MasteryChecklist.tsx
@@ -49,7 +49,7 @@ export default function MasteryChecklist({
   ];
 
   const handleOpenChange = (v: boolean) => {
-    if (!v) setMasteryDismissed(true);
+    // Do not mark dismissed automatically on close; only via explicit close button
     onOpenChange(v);
   };
 
@@ -60,11 +60,22 @@ export default function MasteryChecklist({
         <DialogDescription className="sr-only">Complete these steps to unlock your full VAIS potential</DialogDescription>
         <div className="bg-white rounded-lg shadow-xl max-h-[540px]">
           {/* Header */}
-          <div className="px-6 pt-5 pb-4">
+          <div className="px-6 pt-5 pb-4 relative">
             <h2 className="text-xl font-semibold text-[#333333]">VAIS Mastery Steps Guide</h2>
             <p className="text-sm text-[#666] mt-1">
               Complete these steps to unlock your full VAIS potential 🚀
             </p>
+            <button
+              aria-label="Close"
+              className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
+              onClick={() => {
+                setMasteryDismissed(true);
+                onOpenChange(false);
+              }}
+              title="Dismiss"
+            >
+              ✕
+            </button>
             <div className="mt-4 h-px bg-gray-200" />
           </div>
 

--- a/client/components/onboarding/OnboardingIllustration.tsx
+++ b/client/components/onboarding/OnboardingIllustration.tsx
@@ -92,7 +92,11 @@ export default function OnboardingIllustration({
               className="relative mx-auto w-full max-w-2xl rounded-2xl overflow-hidden shadow-2xl ring-1 ring-white/30 backdrop-blur-sm glow"
               style={{ transformStyle: "preserve-3d" }}
             >
-              <img src={imageSrc} alt={imageAlt} className="block w-full h-auto" />
+              <img
+                src={imageSrc}
+                alt={imageAlt}
+                className="block w-full h-auto"
+              />
             </motion.div>
           ) : (
             <motion.div variants={fadeInUp}>

--- a/client/components/onboarding/OnboardingIllustration.tsx
+++ b/client/components/onboarding/OnboardingIllustration.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { motion } from "framer-motion";
 
 type Variant = "role" | "usecase" | "experience" | "industry" | "category";
 
@@ -30,6 +31,11 @@ const TITLES: Record<Variant, { title: string; subtitle: string }> = {
   },
 };
 
+const fadeInUp = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+};
+
 export default function OnboardingIllustration({
   variant,
   imageSrc,
@@ -43,28 +49,57 @@ export default function OnboardingIllustration({
 
   return (
     <div className="relative h-full w-full overflow-hidden">
+      {/* Animated gradient backdrop */}
       <div className="absolute inset-0 bg-gradient-to-br from-valasys-blue/30 via-valasys-orange/20 to-valasys-green/20" />
-      <div className="absolute -top-24 -left-24 h-80 w-80 rounded-full bg-white/10 blur-2xl" />
-      <div className="absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-black/10 blur-3xl" />
+
+      {/* Subtle moving blobs */}
+      <motion.div
+        className="absolute -top-24 -left-24 h-80 w-80 rounded-full bg-white/10 blur-2xl"
+        animate={{ x: [0, -12, 0], y: [0, 8, 0] }}
+        transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+      />
+      <motion.div
+        className="absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-black/10 blur-3xl"
+        animate={{ x: [0, 14, 0], y: [0, -10, 0] }}
+        transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
+      />
 
       <div className="relative h-full w-full flex items-center justify-center px-8">
-        <div className="max-w-2xl w-full">
-          <h2 className="text-black text-2xl font-semibold">{copy.title}</h2>
-          <p className="text-black text-sm mt-1 mb-6 max-w-xl">
+        <motion.div
+          className="max-w-2xl w-full"
+          initial="initial"
+          animate="animate"
+          transition={{ staggerChildren: 0.08 }}
+        >
+          <motion.h2
+            variants={fadeInUp}
+            className="text-black text-2xl font-semibold"
+          >
+            {copy.title}
+          </motion.h2>
+          <motion.p
+            variants={fadeInUp}
+            className="text-black text-sm mt-1 mb-6 max-w-xl"
+          >
             {copy.subtitle}
-          </p>
+          </motion.p>
+
           {imageSrc ? (
-            <div className="relative mx-auto w-full max-w-2xl rounded-2xl overflow-hidden shadow-2xl ring-1 ring-white/30 backdrop-blur-sm">
-              <img
-                src={imageSrc}
-                alt={imageAlt}
-                className="block w-full h-auto"
-              />
-            </div>
+            <motion.div
+              variants={fadeInUp}
+              whileHover={{ scale: 1.02, rotateX: 2, rotateY: -2 }}
+              whileTap={{ scale: 0.99 }}
+              className="relative mx-auto w-full max-w-2xl rounded-2xl overflow-hidden shadow-2xl ring-1 ring-white/30 backdrop-blur-sm glow"
+              style={{ transformStyle: "preserve-3d" }}
+            >
+              <img src={imageSrc} alt={imageAlt} className="block w-full h-auto" />
+            </motion.div>
           ) : (
-            <DevicePreview />
+            <motion.div variants={fadeInUp}>
+              <DevicePreview />
+            </motion.div>
           )}
-        </div>
+        </motion.div>
       </div>
     </div>
   );
@@ -82,20 +117,44 @@ function DevicePreview() {
         </div>
         {/* Content */}
         <div className="p-4 grid grid-cols-2 gap-4">
-          <div className="col-span-2">
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+            className="col-span-2"
+          >
             <div className="h-32 rounded-xl bg-gradient-to-br from-valasys-orange/90 to-pink-500/80 shadow-md" />
-          </div>
-          <div className="h-20 rounded-xl bg-gradient-to-br from-sky-500/90 to-indigo-500/80 shadow" />
-          <div className="h-20 rounded-xl bg-gradient-to-br from-emerald-500/90 to-teal-500/80 shadow" />
-          <div className="col-span-2 h-10 rounded-md bg-valasys-gray-100" />
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, delay: 0.05 }}
+            className="h-20 rounded-xl bg-gradient-to-br from-sky-500/90 to-indigo-500/80 shadow"
+          />
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, delay: 0.1 }}
+            className="h-20 rounded-xl bg-gradient-to-br from-emerald-500/90 to-teal-500/80 shadow"
+          />
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, delay: 0.15 }}
+            className="col-span-2 h-10 rounded-md bg-valasys-gray-100"
+          />
         </div>
       </div>
       {/* Floating card */}
-      <div className="absolute -right-6 -bottom-6 w-36 rounded-xl bg-white/95 p-3 shadow-2xl ring-1 ring-black/5">
+      <motion.div
+        className="absolute -right-6 -bottom-6 w-36 rounded-xl bg-white/95 p-3 shadow-2xl ring-1 ring-black/5 float-animation"
+        animate={{ y: [0, -6, 0] }}
+        transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+      >
         <div className="h-20 rounded-lg bg-gradient-to-br from-violet-500/90 to-fuchsia-500/80" />
         <div className="mt-2 h-2 w-5/6 rounded bg-valasys-gray-200" />
         <div className="mt-1 h-2 w-2/3 rounded bg-valasys-gray-200" />
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/client/lib/masteryStorage.ts
+++ b/client/lib/masteryStorage.ts
@@ -1,0 +1,74 @@
+export type MasterySteps = {
+  // Always considered completed per requirements
+  signUp?: boolean; // kept for completeness
+  onboardingCompleted?: boolean;
+  vaisResultsGenerated?: boolean;
+  accountsDownloaded?: boolean;
+  prospectSearchGenerated?: boolean;
+  prospectDetailsDownloaded?: boolean;
+  dismissed?: boolean; // whether the checklist auto-popup is dismissed
+  firstSeenAt?: number;
+};
+
+const KEY = "vais.mastery";
+export const MASTERY_EVENT = "vais:mastery-updated";
+
+function canUseStorage() {
+  return (
+    typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+  );
+}
+
+export function getMastery(): MasterySteps {
+  if (!canUseStorage()) return {};
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as MasterySteps) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveMastery(patch: Partial<MasterySteps>) {
+  if (!canUseStorage()) return;
+  const current = getMastery();
+  const next: MasterySteps = { ...current, ...patch };
+  if (next.firstSeenAt == null) next.firstSeenAt = Date.now();
+  localStorage.setItem(KEY, JSON.stringify(next));
+  emitMasteryUpdate(next);
+}
+
+export function markStepCompleted(
+  step:
+    | "onboardingCompleted"
+    | "vaisResultsGenerated"
+    | "accountsDownloaded"
+    | "prospectSearchGenerated"
+    | "prospectDetailsDownloaded",
+) {
+  saveMastery({ [step]: true } as Partial<MasterySteps>);
+}
+
+export function setMasteryDismissed(dismissed: boolean) {
+  saveMastery({ dismissed });
+}
+
+export function calculateMasteryPercentage(state?: MasterySteps) {
+  const s = state ?? getMastery();
+  // 6 steps total; sign up always counts as completed
+  const total = 6;
+  let completed = 1; // sign up
+  if (s.onboardingCompleted) completed++;
+  if (s.vaisResultsGenerated) completed++;
+  if (s.accountsDownloaded) completed++;
+  if (s.prospectSearchGenerated) completed++;
+  if (s.prospectDetailsDownloaded) completed++;
+  return Math.round((completed / total) * 100);
+}
+
+export function emitMasteryUpdate(state: MasterySteps) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(MASTERY_EVENT, { detail: state }) as Event,
+  );
+}

--- a/client/pages/OnboardingThankYou.tsx
+++ b/client/pages/OnboardingThankYou.tsx
@@ -18,6 +18,7 @@ import { useNavigate } from "react-router-dom";
 import OnboardingDecor from "@/components/onboarding/Decor";
 import ConfettiCanvas from "@/components/onboarding/ConfettiCanvas";
 import { CheckCircle2 } from "lucide-react";
+import { markStepCompleted } from "@/lib/masteryStorage";
 
 export default function OnboardingThankYou() {
   const navigate = useNavigate();

--- a/client/pages/OnboardingThankYou.tsx
+++ b/client/pages/OnboardingThankYou.tsx
@@ -25,6 +25,9 @@ export default function OnboardingThankYou() {
   const data = getOnboarding();
 
   const continueToApp = () => {
+    // Mark onboarding as completed for Mastery progress
+    markStepCompleted("onboardingCompleted");
+
     clearOnboarding();
     clearOnboardingSkipReminder();
     emitOnboardingSkipReminderUpdate(null);


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements a redesigned mastery guide system that:
- Moves the mastery guide from a top navigation button to a fixed bottom position
- Replaces popup modals with a slide-up dropdown interface for better UX
- Adds next step suggestions above the progress bar when collapsed
- Improves the visual design with better gradient colors and increased height
- Ensures the mastery guide persists across page refreshes until all steps are completed

## Code changes

- **Added `MasteryBottomBar.tsx`**: New component that renders a fixed bottom bar with:
  - Collapsible slide-up panel showing all mastery steps
  - Next step suggestion bar when collapsed
  - Progress bar with improved gradient styling
  - Persistent state management across page refreshes

- **Added `MasteryChecklist.tsx`**: Modal version of the mastery checklist (appears to be legacy/backup component)

- **Added `masteryStorage.ts`**: Utility functions for managing mastery progress state in localStorage with event-driven updates

- **Updated `DashboardLayout.tsx`**: Integrated the new `MasteryBottomBar` component into the main layout

- **Updated `OnboardingIllustration.tsx`**: Enhanced with motion animations and improved visual effects

- **Updated `OnboardingThankYou.tsx`**: Added mastery step completion tracking when onboarding finishes

The implementation uses Framer Motion for smooth animations and maintains all existing mastery tracking functionality while providing the requested slide-up interface design.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df9841c0bfab460699cf35d9dc2b9c6d/vortex-zone)

👀 [Preview Link](https://df9841c0bfab460699cf35d9dc2b9c6d-vortex-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df9841c0bfab460699cf35d9dc2b9c6d</projectId>-->
<!--<branchName>vortex-zone</branchName>-->